### PR TITLE
State Machine: Add more states (#2)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "BusOut.h"
 #include "DigitalOut.h"
+#include "EventFlags.h"
 #include "InterfaceDigitalIn.h"
 #include "InterruptIn.h"
 #include "LowPowerTicker.h"
@@ -8,81 +9,102 @@
 #include "PinNames.h"
 #include "PinNamesTypes.h"
 #include "ThisThread.h"
+#include "config.h"
 #include "mbed.h"
+#include "state_machine.h"
 #include <chrono>
 #include <cstdio>
 #include <ctime>
 
 // POLLING_FREQ is the polling rate to be used in a polling ticker.
 constexpr auto POLLING_FREQ = 100ms;
-// INPUT_BTN is the btn to be used for inputs.
-constexpr auto INPUT_BTN = D2;
-// HOLD_TIME defines the length of time required to register a btn hold. (The
-// real time value of this constant is computed by the POLLING_FREQ * HOLD_TIME)
-const int HOLD_TIME = 50;
+
+// OFF_BTN is the btn to be used for emergency off, and powering up.
+constexpr auto OFF_BTN = D2;
+
+// START_BTN is the btn to be used for changing states form LV to HV.
+constexpr auto START_BTN = D3;
+
+// EMERGENCY_RESET_TIME defines the length of time required to register a btn
+// hold for an emergency state reset. (The real time value of this constant is
+// computed by the POLLING_FREQ * EMERGENCY_RESET_TIME)
+const int EMERGENCY_RESET_TIME = 50;
+
+// START_BTN_HOLD_TIME defines the length of time required to register a btn
+// hold for a the START_BTN (The real time value of this constant is
+// computed by the POLLING_FREQ * START_BTN_HOLD_TIME)
+const int START_BTN_HOLD_TIME = 20;
 
 // Define button press interrupt.
-InterruptIn btn(INPUT_BTN, PullUp);
+InterruptIn off_btn(OFF_BTN, PullUp);
+InterruptIn start_btn(START_BTN, PullUp);
 
-// Setup status LED
-DigitalOut emergency(D3); // Red.
-
-// Setup on board LEDs.
+// Setup on board LEDs for writing state.
 BusOut onboard_leds(LED1, LED2, LED3);
 
 // Define a ticker to poll inputs.
 Ticker polling_ticker;
 
-// Define a variable which tracks how long the INPUT_BTN has been held for.
-volatile int btn_held_count;
+// Define an event flag to manage state changes from ISR.
+EventFlags flags;
 
-// emergency_irq is used to put the car into the emergency state. This state
-// turns off all electronics until the system is rebooted, or the state is
-// exited by holding down the button for 5 seconds.
+// Create a state machine which handles the state of the car.
+StateMachine state_machine = StateMachine(&flags);
+
+// Define a variable which tracks how long the OFF_BTN has been held for.
+volatile int off_btn_held_count;
+
+// Define a variable which tracks how long the START_BTN has been held for.
+volatile int start_btn_held_count;
+
+// emergency_irq is used to put the car into the OFF state on a single button
+// press.
 void emergency_irq() {
   // Set the emergency state unless the button has been held.
-  if (btn_held_count < HOLD_TIME) {
-    emergency = 1;
+  if (off_btn_held_count < EMERGENCY_RESET_TIME) {
+    flags.set(state::OFF_PRESS);
   }
 }
 
 // poll() is used to poll at the POLLING_FREQ for reading different inputs. poll
 // can be used to keep track of button holding, and other inputs.
 void poll_irq() {
-  if (!btn.read()) {
-    btn_held_count++;
-    if (btn_held_count >= HOLD_TIME) {
-      emergency = 0;
+  // Read the OFF_BTN.
+  if (!off_btn.read()) {
+    off_btn_held_count++;
+    if (off_btn_held_count >= EMERGENCY_RESET_TIME) {
+      flags.set(state::OFF_HOLD);
     }
   } else {
-    btn_held_count = 0;
+    off_btn_held_count = 0;
+  };
+
+  // Read the START_BTN.
+  if (!start_btn.read()) {
+    start_btn_held_count++;
+    if (start_btn_held_count >= START_BTN_HOLD_TIME) {
+      flags.set(state::START_HOLD);
+      start_btn_held_count = 0;
+    }
+  } else {
+    start_btn_held_count = 0;
   };
 }
 
 // main() runs in its own thread in the OS
 int main() {
-  // Poll the button to check for button holds.
+  //   Poll to check for button holds.
   polling_ticker.attach(&poll_irq, POLLING_FREQ);
 
-  // Set interupt handlers.
-  btn.rise(&emergency_irq);
+  //   Set interupt handlers.
+  off_btn.rise(&emergency_irq);
 
   while (true) {
-    if (emergency) {
-      // Flash LEDs.
-      onboard_leds = 0;
-      ThisThread::sleep_for(300ms);
-      onboard_leds = 7;
-      ThisThread::sleep_for(300ms);
-    } else {
-      // Count up in binary.
-      for (int i = 0; i < 8; i++) {
-        if (emergency) {
-          break;
-        }
-        onboard_leds = i;
-        ThisThread::sleep_for(300ms);
-      }
+    // Read the event flags to check for a state update. These flags are set in
+    // the interrupt handlers.
+    if (flags.get() != 0) {
+      state_machine.next_state();
+      onboard_leds.write(state_machine.get_state());
     }
   }
 }

--- a/state_machine.cpp
+++ b/state_machine.cpp
@@ -1,0 +1,47 @@
+#include "state_machine.h"
+#include "BusOut.h"
+#include "EventFlags.h"
+
+StateMachine::StateMachine(rtos::EventFlags *flags)
+    : _current_state(state::OFF), _flags(flags) {}
+
+void StateMachine::next_state() {
+  // Get the interaction from the event flag, then clear the flags.
+  uint32_t interaction = _flags->get();
+  _flags->clear();
+
+  switch (_current_state) {
+  case state::OFF: // The car is currrently powered off.
+    switch (interaction) {
+    case state::OFF_HOLD: // The OFF_BTN has been held, ready to turn on low
+                          // voltage.
+      _current_state = state::LV;
+      break;
+    }
+    break;
+  case state::LV:
+    switch (interaction) {
+    case state::OFF_PRESS:
+      _current_state = state::OFF;
+      break;
+    case state::START_HOLD:
+      _current_state = state::HV;
+      break;
+    }
+    break;
+  case state::HV:
+    switch (interaction) {
+    case state::OFF_PRESS:
+      _current_state = state::OFF;
+      break;
+    case state::START_HOLD:
+      _current_state = state::LV;
+      break;
+    }
+    break;
+  default:
+    _current_state = state::OFF;
+  }
+}
+
+int StateMachine::get_state() { return _current_state; }

--- a/state_machine.h
+++ b/state_machine.h
@@ -1,0 +1,63 @@
+#ifndef STATE_MACHINE_H
+#define STATE_MACHINE_H
+
+#include "BusOut.h"
+#include "EventFlags.h"
+#include <cstdint>
+
+// Define the namespace of these values to be state.
+namespace state {
+
+/** states enumerates the states of the vehicle. The states are:
+ *      OFF:    None of the electronics of the car are active.
+ *              We should start in this state.
+ *
+ *      LV:     The 12v supply rail is on. This powers up all 12V connected
+ *              electronics.
+ *
+ *      HV:     The highvoltage BMS connection in closed. This allows the power
+ *              flow to the motor controller.
+ */
+enum states { OFF, LV, HV };
+
+// Define the event flags which signal which of the following interactions have
+// been made.
+const std::uint32_t OFF_HOLD(1UL << 1);    // A long press of the OFF_BTN.
+const std::uint32_t OFF_PRESS(1UL << 0);   // A single press of the OFF_BTN.
+const std::uint32_t START_PRESS(1UL << 2); // A single press of the START_BTN.
+const std::uint32_t START_HOLD(1UL << 3);  // A long press of the START_BTN.
+
+} // namespace state
+
+/* StateMachine stores the current state of the vehicle and handles updates to
+ * the current state through the event flags. Calls to next_state should be made
+ * whenever the event flags are non-nill, these calls should come from the main
+ * execution loop.
+ */
+class StateMachine {
+  int _current_state;
+  rtos::EventFlags *_flags;
+
+public:
+  /* The constructor sets the initial state to OFF, and gets the EventFlags
+   * object.
+   *
+   * @param flags EventFlags object used to pass interactions from an ISR
+   * context.
+   */
+  StateMachine(rtos::EventFlags *flags);
+
+  /* Set the state of the vehicle given an interaction passed via the event
+   * flags.
+   */
+  void next_state();
+
+  /* Get the current state of the vehicle as an enumerated value.
+   *
+   * @returns
+   *    An enumerated value of the current state.
+   */
+  int get_state();
+};
+
+#endif


### PR DESCRIPTION
The VCM now supports 3 states as defined in #2. A new state machine class has been defined which will handle state changes via event flags. The event flags are written by the interrupt handlers, and read by the state machine to make the relevant update to the state.